### PR TITLE
Fix spacing in the GMail filter

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,5 +1,5 @@
 get '/' do
   @recruiters = YAML.load_file('recruiters.yml')
-  filter = '*@' + [@recruiters['thirdparty'] + @recruiters['companies'] + @recruiters['other']].flatten.join('OR *@')
+  filter = '*@' + [@recruiters['thirdparty'] + @recruiters['companies'] + @recruiters['other']].flatten.join(' OR *@')
   erb :index, locals: { recruiters: @recruiters, filter: filter }
 end


### PR DESCRIPTION
The `OR`s got mashed in with the domains
