### PR TITLE
Please remove rockmelt.com

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -123,7 +123,6 @@ companies:
   - life360.com
   - lumoslabs.com
   - plumdistrict.net
-  - rockmelt.com
   - rovicorp.com
   - sungard.com
 other:


### PR DESCRIPTION
I apologize if you have received poor email communication or had a poor
experience with someone from RockMelt.  The goal of my team and the
company is to hold the upmost professional experience with people we
reach out to.  This is one of the reasons I love working for RockMelt
is because of the commitment to world class service of people we meet
and reach out to.

I would be happy to set up time to talk with you to learn what happened
or what the situation was that caused the rockmelt.com domain to be
added as an undesirable company.  I hope to have an opportunity for our
company to be removed from this blog as I strongly feel the customer
service we provide to candidates is above and beyond what most
companies offer.  We get back to every candidate that applies to a
position and when someone interviews with us, we provide them lunch as
part of the interview process.  We also try to reach out to people not
just for a job opportunity with us, but we give them the opportunity to
add us to their network.  Our company is connected to some of the top
VCs in the valley and if someone is connected to us, but not interested
in working here, we can help them work for any of our VC portfolio
companies.

RockMelt is full of great engineers working together to do great
things.  We believe in open source technology and helping the
technology industry grow.
