### PR TITLE
Add recruiting.la

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -79,6 +79,7 @@ thirdparty:
   - recruiting.la
   - redrobotlabs.com
   - resourcis.com
+  - retainedsearch.vc
   - redfishtech.com
   - rivierapartners.com
   - saksys.com


### PR DESCRIPTION
I don't know if I like or hate that they used a mailing list service. It's
extra insulting, but there's an unsubscribe link. At any rate, he led with
this nonsense:

> Your resume needs mobile social video experience.
> 
> Why?: Developing a platform API for developers and mobile video experiences is
> the hottest experience you can get.  Viddy and SocialCam are exploding -
> adding 10M users a week - but they don't use Rails.
> 
> Use Rails at my client to take social video sharing to the next level.  My
> client is well funded, has an app with traction and a great UX and is
> currently building its public API.  Also, they are entertainment and celebrity
> focused - a rare opportunity in SF.
