### PR TITLE
Remove monetate.com.. not a recruiting company.

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -103,7 +103,6 @@ thirdparty:
   - mint-rs.com
   - modis.com
   - mondo.com
-  - monetate.com
   - motionrecruitment.com
   - mriboise.com
   - newbees-it.com


### PR DESCRIPTION
Monetate is a startup in Philly that sells software to marketers. I'm on the engineering team there.
