### PR TITLE
Adding chenoainc.com to third-party recruiters.

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -36,6 +36,7 @@ thirdparty:
   - captainrecruiter.com
   - capitalmarketsp.com
   - changepond.com
+  - chenoainc.com
   - chiefpeople.com
   - cloudeeva.com
   - collabera.com


### PR DESCRIPTION
Reason: completely untargeted email (mid-level web contract sent to my work address.  clearly hadn't even skimmed my profile.)
