### PR TITLE
Remove monetate.com, as it's not a third-party recruiter

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -109,7 +109,6 @@ thirdparty:
   - mint-rs.com
   - modis.com
   - mondo.com
-  - monetate.com
   - motionrecruitment.com
   - mriboise.com
   - newbees-it.com


### PR DESCRIPTION
I'm on the engineering team here at Monetate, and we're definitely not a third-party recruiter.  We're just a tech startup based in Philly (though one that also hires remote engineers)
