### PR TITLE
removing monetate

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -107,7 +107,6 @@ thirdparty:
   - mint-rs.com
   - modis.com
   - mondo.com
-  - monetate.com
   - motionrecruitment.com
   - mriboise.com
   - newbees-it.com


### PR DESCRIPTION
A Sr. Recruiter working for Monetate was using linkedin to publish contests, not unsolicited employment opportunities.  I misinterpreted her emails as recruiter spam vs. the usual LinkedIn noise.
