### PR TITLE
Added 2 domains of 3rd party reqruiters

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -64,6 +64,8 @@ thirdparty:
   - encoress.com
   - epro-consulting.com
   - erpanderp.com
+  - eurostaffgroup.com
+  - eurostaffsolutions.com
   - everestinc.com
   - expanxion.net
   - experis.com
@@ -195,8 +197,6 @@ thirdparty:
   - wirelessmobisolution.com
   - workbridgeassociates.com
   - xcreek.com
-  - eurostaffgroup.com
-  - eurostaffsolutions.com
 other:
   - githire.com
   - jobvite.com


### PR DESCRIPTION
Received multiple e-mails from addresses of these hosts (eurostaffgroup.com and eurostaffsolutions.com), all quite impersonal. Tried to unsubscribe from these lists, but their mailinglist service always returns a 500 and the people sending these e-mail either don't listen, or reply to me as follows after asking to be removed from their address list:

> I know you are currently  NOT looking, but maybe you know of a colleague/friend looking for a change?
