### PR TITLE
Added sutrajobs.com

### DIFF
--- a/recruiters.yml
+++ b/recruiters.yml
@@ -216,6 +216,7 @@ thirdparty:
   - sunrisesys.com
   - surrex.com
   - summitgroupsolutions.com
+  - sutrajobs.com
   - swingtalent.com
   - synapseint.com
   - sysdevit.com


### PR DESCRIPTION
SutraHR is an Indian startup recruiting agency that spams indiscriminately, ignoring requests to stop. Their email comes from @sutrajobs.com.
